### PR TITLE
Restore weekly menu import system

### DIFF
--- a/src/app/api/menu-upload/route.ts
+++ b/src/app/api/menu-upload/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { writeFile, stat } from "fs/promises";
+import path from "path";
+
+export const runtime = "nodejs";
+
+function isPdf(file: File | null): file is File {
+  return !!file && (file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf"));
+}
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData();
+    const { searchParams } = new URL(request.url);
+    const wantsRedirect = searchParams.get("redirect") === "1";
+    const menuEquilibre = formData.get("menuEquilibre");
+    const menuTraiteur = formData.get("menuTraiteur");
+
+    const filesToWrite: Array<{ targetName: string; file: File }> = [];
+
+    if (menuEquilibre instanceof File) {
+      if (!isPdf(menuEquilibre)) {
+        return NextResponse.json({ ok: false, error: "Le fichier Équilibre doit être un PDF." }, { status: 400 });
+      }
+      filesToWrite.push({ targetName: "menu-equilibre.pdf", file: menuEquilibre });
+    }
+
+    if (menuTraiteur instanceof File) {
+      if (!isPdf(menuTraiteur)) {
+        return NextResponse.json({ ok: false, error: "Le fichier Traiteur doit être un PDF." }, { status: 400 });
+      }
+      filesToWrite.push({ targetName: "menu-traiteur.pdf", file: menuTraiteur });
+    }
+
+    if (filesToWrite.length === 0) {
+      if (wantsRedirect) {
+        return NextResponse.redirect(new URL("/menu?error=Aucun%20fichier%20re%C3%A7u.", request.url));
+      }
+      return NextResponse.json({ ok: false, error: "Aucun fichier reçu." }, { status: 400 });
+    }
+
+    const publicDir = path.join(process.cwd(), "public");
+
+    const results: Record<string, string> = {};
+
+    for (const { targetName, file } of filesToWrite) {
+      const bytes = Buffer.from(await file.arrayBuffer());
+      const targetPath = path.join(publicDir, targetName);
+
+      // Optional: ensure public dir exists (it does in this app, but keep a safe check)
+      try {
+        await stat(publicDir);
+      } catch {
+        // ignore; Next apps include public/
+      }
+
+      await writeFile(targetPath, bytes);
+      results[targetName] = "updated";
+    }
+
+    if (wantsRedirect) {
+      return NextResponse.redirect(new URL("/menu?success=1", request.url));
+    }
+    return NextResponse.json({ ok: true, updated: results });
+  } catch (error) {
+    const message = "Erreur lors du téléversement.";
+    try {
+      const { searchParams } = new URL(request.url);
+      const wantsRedirect = searchParams.get("redirect") === "1";
+      if (wantsRedirect) {
+        return NextResponse.redirect(new URL(`/menu?error=${encodeURIComponent(message)}`, request.url));
+      }
+    } catch {}
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,0 +1,46 @@
+export default function MenuUploadPage({ searchParams }: { searchParams: { success?: string; error?: string } }) {
+  const success = searchParams?.success === "1";
+  const error = searchParams?.error;
+
+  return (
+    <section className="container mx-auto px-6 sm:px-8 py-12">
+      <h1 className="text-2xl sm:text-3xl font-semibold">Mettre à jour les menus (PDF)</h1>
+      <p className="mt-2 text-sm text-black/70">
+        Importez les nouveaux fichiers. Ils remplaceront `public/menu-equilibre.pdf` et `public/menu-traiteur.pdf`.
+      </p>
+
+      <form action="/api/menu-upload?redirect=1" method="post" encType="multipart/form-data" className="mt-6 grid gap-6 max-w-xl">
+        <div>
+          <label className="block text-sm font-medium">Menu Équilibre (PDF)</label>
+          <input
+            type="file"
+            name="menuEquilibre"
+            accept="application/pdf"
+            className="mt-2 block w-full border rounded-md p-2"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Menu Traiteur (PDF)</label>
+          <input
+            type="file"
+            name="menuTraiteur"
+            accept="application/pdf"
+            className="mt-2 block w-full border rounded-md p-2"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-md bg-black text-white px-4 py-2 text-sm font-medium hover:bg-black/90"
+        >
+          Mettre à jour
+        </button>
+
+        {success && <p className="text-green-600 text-sm">Menus mis à jour avec succès.</p>}
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+      </form>
+    </section>
+  );
+}
+


### PR DESCRIPTION
Add a `/menu` page and API endpoint to upload and update the `menu-equilibre.pdf` and `menu-traiteur.pdf` files.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef93c876-c5cb-41c3-affb-afcc76f25744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef93c876-c5cb-41c3-affb-afcc76f25744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

